### PR TITLE
Fix library dependency(linking) order when building executables

### DIFF
--- a/src/bin/Makefile.am
+++ b/src/bin/Makefile.am
@@ -1,18 +1,18 @@
 
 AM_CPPFLAGS = -I$(srcdir)/../include $(BOOST_CPPFLAGS)
-AM_LDFLAGS = $(BOOST_LDFLAGS) $(BOOST_THREAD_LIB) $(BOOST_REGEX_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)
+AM_LDFLAGS =
 
 
 bin_PROGRAMS = train-lader lader evaluate-lader label-ranking
 
 train_lader_SOURCES = train-lader.cc
-train_lader_LDADD = ../lib/liblader.la
+train_lader_LDADD = ../lib/liblader.la $(BOOST_LDFLAGS) $(BOOST_THREAD_LIB) $(BOOST_REGEX_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)
 
 lader_SOURCES = lader.cc
-lader_LDADD = ../lib/liblader.la
+lader_LDADD = ../lib/liblader.la $(BOOST_LDFLAGS) $(BOOST_THREAD_LIB) $(BOOST_REGEX_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)
 
 evaluate_lader_SOURCES = evaluate-lader.cc
-evaluate_lader_LDADD = ../lib/liblader.la
+evaluate_lader_LDADD = ../lib/liblader.la $(BOOST_LDFLAGS) $(BOOST_THREAD_LIB) $(BOOST_REGEX_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)
 
 label_ranking_SOURCES = label-ranking.cc
-label_ranking_LDADD = ../lib/liblader.la
+label_ranking_LDADD = ../lib/liblader.la $(BOOST_LDFLAGS) $(BOOST_THREAD_LIB) $(BOOST_REGEX_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -1,9 +1,9 @@
 LADERTH = test-alignments-and-ranks.h test-feature-vector.h test-base.h test-hyper-graph.h test-dictionary.h test-loss-bracket.h test-feature-align.h test-loss-chunk.h test-feature-parse.h test-loss-tau.h test-feature-sequence.h test-reorderer-model.h test-feature-set.h
 
 AM_CPPFLAGS = -I$(srcdir)/../include -DPKGDATADIR='"$(pkgdatadir)"' $(BOOST_CPPFLAGS)
-AM_LDFLAGS = $(BOOST_LDFLAGS) $(BOOST_THREAD_LIB) $(BOOST_REGEX_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)
+AM_LDFLAGS =
 
 bin_PROGRAMS = test-lader
 
 test_lader_SOURCES = test-lader.cc ${LADERTH}
-test_lader_LDADD = ../lib/liblader.la
+test_lader_LDADD = ../lib/liblader.la $(BOOST_LDFLAGS) $(BOOST_THREAD_LIB) $(BOOST_REGEX_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_FILESYSTEM_LIB)


### PR DESCRIPTION
This PR modifies src/bin/Makefile.am and src/test/Makefile.am, to fix library dependency order when building executables (train_lader, lader, evaluate_lader, label_ranking, and test_lader), which could be raise 'undefined reference' errors, e.g.
>> ../lib/.libs/liblader.so: undefined reference to `boost::detail::get_current_thread_data()'

even though "configure" defines boost-related configuration variables successfully.

boost library linking options must be written after liblader.so(.la), since gcc/ld(linker) resolves inter-library dependencies with left-to-right order.

Tested on Ubuntu 14.04, 16.04LTS + distro-default packages of boost library (for Ubuntu 14.04, boost-1.54, and 1.58 for Ubuntu 16.04LTS), and Boost 1.68.